### PR TITLE
Fixing contribution (missing signature in session)

### DIFF
--- a/imports/ui/pages/contribution.js
+++ b/imports/ui/pages/contribution.js
@@ -172,6 +172,9 @@ Template.contribution.events({
                 // Big-endian encoding of uint, padded on the higher-order (left) side with zero-bytes such that the length is a multiple of 32 bytes
                 const vHex = web3.fromDecimal(v).slice(2);
                 const data = `${methodId}${'0'.repeat(64 - vHex.length)}${vHex}${r.slice(2)}${s.slice(2)}`;
+                Session.set('sig.v', v);
+                Session.set('sig.r', r);
+                Session.set('sig.s', s);
                 Session.set('tx.data', data);                
                 Session.set('isECParamsSet', true);
                 Toast.success('Signature successfully generated');


### PR DESCRIPTION
Signature is required to call function here:
https://github.com/tomusdrw/contribution/blob/1dc22e7d2c96e49094d8b72e0e1695472632e701/imports/ui/pages/contribution.js#L204-L206

Instead you might use `web3.eth.sendTransaction` with `tx.data` directly (but perhaps it will require waiting for the block to be mined) - let me know if you prefer it this way.